### PR TITLE
restart always also in server container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services :
   web :
     image : ocsinventory/ocsinventory-docker-image:latest
     container_name : ocsinventory-server
+    restart: always
     environment :
       OCS_DBNAME : ocsweb
       OCS_DBSERVER_READ : ocsinventory-db


### PR DESCRIPTION
## Status
**READY**

## Description
It allows to have the server running after a downtime (e.g. physical machine restart).

## Todos
- [x] Tests
- [x] Documentation

## Test environment
If some tests has been already made, please give us your test environment' specs

#### General informations
Docker host's operating system :
```
$ hostnamectl
  Operating System: Debian GNU/Linux 9 (stretch)
            Kernel: Linux 3.16.0-4-amd64
      Architecture: x86-64
```


#### Docker informations
Docker compose version :
```
$ docker-compose --version
docker-compose version 1.23.2, build 1110ad01
```

Docker version :
```
$ docker --version
Docker version 18.09.2, build 6247962
```
